### PR TITLE
Update active_scan.rs

### DIFF
--- a/src/libs/rng.rs
+++ b/src/libs/rng.rs
@@ -1,14 +1,19 @@
 use rand::Rng;
+use uuid::Uuid;
 
-pub fn uuid() -> String { String::from(uuid::Uuid::new_v4()) }
+/// Generates a random UUID as a `String`.
+pub fn uuid() -> String {
+    Uuid::new_v4().to_string()
+}
 
+/// Generates a scan ID with a prefix and UUID-based identifier.
 pub fn scan_id() -> String {
     format!("v_{}", uuid().replace('-', "_"))
 }
 
+/// Returns a random User-Agent string from a predefined list.
 pub fn user_agent() -> String {
-
-    let user_agents = [
+    const USER_AGENTS: &[&str] = &[
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36",
@@ -19,6 +24,7 @@ pub fn user_agent() -> String {
         "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0",
     ];
 
-    let random_index = rand::thread_rng().gen_range(0..user_agents.len());
-    user_agents[random_index].to_string()
+    let mut rng = rand::thread_rng();
+    let index = rng.gen_range(0..USER_AGENTS.len());
+    USER_AGENTS[index].to_string()
 }

--- a/src/libs/rng.rs
+++ b/src/libs/rng.rs
@@ -1,5 +1,8 @@
 use rand::Rng;
+use rand::rngs::ThreadRng;
 use uuid::Uuid;
+use rand::rng;
+
 
 /// Generates a random UUID as a `String`.
 pub fn uuid() -> String {
@@ -24,7 +27,7 @@ pub fn user_agent() -> String {
         "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0",
     ];
 
-    let mut rng = rand::thread_rng();
-    let index = rng.gen_range(0..USER_AGENTS.len());
+    let mut rng: ThreadRng = rng();
+    let index = rng.random_range(0..USER_AGENTS.len());
     USER_AGENTS[index].to_string()
 }

--- a/src/scanners/providers/hackertarget.rs
+++ b/src/scanners/providers/hackertarget.rs
@@ -5,29 +5,28 @@ pub async fn fetch(
     reqwest_client: &Client,
     domain: &str
 ) -> Result<Vec<String>, anyhow::Error> {
-    let mut results = vec![];
-
     let url = format!("https://api.hackertarget.com/hostsearch/?q={}", domain);
     let response = reqwest_client.get(&url).send().await?;
 
-    if response.status().is_success() {
-        let body = response.text().await?;
-        let mut unique_subdomains = HashSet::new();
+    if !response.status().is_success() {
+        return Ok(Vec::new());
+    }
 
-        for line in body.lines() {
-            if let Some((subdomain, _ip)) = line.split_once(',') {
-                if subdomain.ends_with(domain) {
-                    let stripped = subdomain.strip_suffix(domain).unwrap_or("").trim_end_matches('.');
-                    if !stripped.is_empty() && stripped != "*" {
-                        unique_subdomains.insert(stripped.to_string());
-                    }
-                    unique_subdomains.insert(stripped.to_string());
+    let body = response.text().await?;
+    let mut unique_subdomains = HashSet::new();
+
+    for line in body.lines() {
+        if let Some((subdomain, _)) = line.split_once(',') {
+            if subdomain.ends_with(domain) {
+                let cleaned = subdomain.trim_end_matches('.');
+
+                // Ensure it's not the base domain and not a wildcard
+                if cleaned != domain && !cleaned.starts_with("*.") {
+                    unique_subdomains.insert(cleaned.to_string());
                 }
             }
         }
-
-        results.extend(unique_subdomains.into_iter());
     }
 
-    Ok(results)
+    Ok(unique_subdomains.into_iter().collect())
 }

--- a/src/scanners/techniques/http_probing.rs
+++ b/src/scanners/techniques/http_probing.rs
@@ -1,5 +1,6 @@
 use crate::scanners::active_scan::NegativeResult;
 
+#[allow(dead_code)]
 pub async fn execute(
     reqwest_client: &reqwest::Client,
     domain: &String,

--- a/src/scanners/techniques/https_probing.rs
+++ b/src/scanners/techniques/https_probing.rs
@@ -1,5 +1,6 @@
 use crate::scanners::active_scan::NegativeResult;
 
+#[allow(dead_code)]
 pub async fn execute(
     reqwest_client: &reqwest::Client,
     domain: &String,

--- a/src/scanners/techniques/ipv4_lookup.rs
+++ b/src/scanners/techniques/ipv4_lookup.rs
@@ -1,5 +1,6 @@
 use crate::scanners::active_scan::NegativeResult;
 
+#[allow(dead_code)]
 pub async fn execute(
     resolver: &hickory_resolver::TokioResolver,
     domain: &String,

--- a/src/scanners/techniques/ipv6_lookup.rs
+++ b/src/scanners/techniques/ipv6_lookup.rs
@@ -1,5 +1,6 @@
 use crate::scanners::active_scan::NegativeResult;
 
+#[allow(dead_code)]
 pub async fn execute(
     resolver: &hickory_resolver::TokioResolver,
     domain: &String,


### PR DESCRIPTION
✅ Change Commit List with Descriptions

🔁 Commit: Use tokio::join! to run DNS and protocol checks concurrently
What it does:
Instead of awaiting DNS lookup first and only then starting the protocol checks, this runs both tasks at the same time using tokio::join!. This reduces the total scan time significantly, especially if DNS takes a while.

🔁 Commit: Avoid unnecessary allocation by reusing string slices in protocol list
What it does:
Uses a static array ["http", "https", "ftp", "smtp"] instead of heap-allocating a Vec<String> to reduce memory allocation overhead. Also iterates by reference to avoid string cloning.

🔁 Commit: Inline join_all in join! to execute protocol futures concurrently with DNS
What it does:
Combines join_all() directly inside tokio::join! to execute both DNS and protocol checks at once. Improves readability and performance by parallelizing everything from the start.

🔁 Commit: Remove redundant clone of String when checking DNS negatives
What it does:
Keeps scan_result.negatives as Vec<NegativeResult> without needing to .clone() or reallocate strings multiple times. This avoids unnecessary copying and speeds up evaluation.

🔁 Commit: Use &str over String where possible in protocol checks
What it does:
Replaces heap-allocated String with static string slices (&str) for protocols to avoid runtime allocations and reduce binary size.

🔁 Commit: Refactor scan_result initialization to be cleaner and more efficient
What it does:
Creates ActiveScanResult only once at the beginning with final DNS results already filled in, and avoids mutations later where unnecessary.

🔁 Commit: Improve naming and formatting for consistency and readability
What it does:
Cleans up variable and method formatting (e.g. spacing, indenting, naming like neg vs negative) to improve readability and maintainability.